### PR TITLE
Fix live demo: self-healing model fetch + slimmer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN mkdir -p models/triage && \
     curl -L -o models/triage/triage_model.keras https://github.com/Thomasbehan/LesNet/releases/download/4.1.0/LesNet.M-4s.keras && \
     curl -L -o models/triage/artifacts.json https://github.com/Thomasbehan/LesNet/releases/download/4.1.0/LesNet.M-4s.artifacts.json
 
-# Add a new user to avoid running the application as root
-RUN useradd -ms /bin/bash appuser
+# Add a new user to avoid running the application as root; let it write the model dir
+# (so the app's self-healing model fetch works at runtime).
+RUN useradd -ms /bin/bash appuser && chown -R appuser /app
 USER appuser
 
 # Make port 6543 available to the world outside this container and 6006 for TensorBoard

--- a/lesnet/views/api.py
+++ b/lesnet/views/api.py
@@ -8,23 +8,53 @@ import logging
 import os
 
 import numpy as np
+import requests
 from PIL import Image
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.view import view_config
 
+from lesnet.config.model import ModelConfig
+from lesnet.ml.artifacts import BUNDLE_FILE, MODEL_FILE
 from lesnet.ml.datasets import LesionRecord
 from lesnet.ml.inference import TriagePredictor
 from lesnet.ml.taxonomy import TRIAGE_CLASSES
 
 log = logging.getLogger(__name__)
 TRIAGE_ARTIFACTS_DIR = os.environ.get('LESNET_TRIAGE_ARTIFACTS', 'models/triage')
+DEFAULT_MODEL_ID = os.environ.get('LESNET_TRIAGE_MODEL', 'M-4s')
 
 _predictor = None
+
+
+def _ensure_triage_model(directory):
+    """Download the released triage model into `directory` if it isn't already there.
+
+    Makes the deployed app self-healing — it fetches the model on first use even if the
+    container image didn't bake it in.
+    """
+    model_path = os.path.join(directory, MODEL_FILE)
+    bundle_path = os.path.join(directory, BUNDLE_FILE)
+    if os.path.exists(model_path) and os.path.exists(bundle_path):
+        return
+    model_url = ModelConfig.MODEL_URLS.get(DEFAULT_MODEL_ID)
+    if not model_url:
+        return
+    os.makedirs(directory, exist_ok=True)
+    for url, destination in [(model_url, model_path),
+                             (model_url.replace('.keras', '.artifacts.json'), bundle_path)]:
+        if os.path.exists(destination):
+            continue
+        log.info("Fetching triage model asset: %s", url)
+        response = requests.get(url, timeout=600)
+        response.raise_for_status()
+        with open(destination, 'wb') as handle:
+            handle.write(response.content)
 
 
 def _get_predictor():
     global _predictor
     if _predictor is None:
+        _ensure_triage_model(TRIAGE_ARTIFACTS_DIR)
         _predictor = TriagePredictor(TRIAGE_ARTIFACTS_DIR)
     return _predictor
 
@@ -60,7 +90,8 @@ def predict_api(request):
 
     try:
         predictor = _get_predictor()
-    except (FileNotFoundError, OSError):
+    except Exception as error:  # noqa: BLE001 - fetch or model-load failure should degrade gracefully
+        log.exception("Triage model unavailable: %s", error)
         request.response.status = 503
         return {'triage': 'abstain', 'valid_image': False, 'reason': 'model_unavailable',
                 'message': 'Triage model is not available yet.'}

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ requires = [
     'tensorboard-plugin-profile==2.16.0',
     'termcolor==2.3.0',
     'tensorflow==2.16.1',
-    'torch==2.5.1',
-    'torchvision==0.20.1',
     'tqdm==4.66.3',
     'vit-keras==0.1.2',
     'tensorflow_addons==0.20.0',


### PR DESCRIPTION
The Render live demo returned `model_unavailable` because the deployed container didn't have the M-4s model at `models/triage/` (it was running the new triage code on the old image/Dockerfile).

- **Self-heal**: `views/api.py` now downloads the released M-4s model + artifact bundle into the artifacts dir on first prediction if it's missing — so the demo works regardless of how the image was built. Failures degrade gracefully.
- **Dockerfile**: `chown` /app to the runtime user so that fetch can write.
- **Slimmer build**: drop unused `torch`/`torchvision` (never imported) — large dependencies that bloated the Render build.