### PR TITLE
fix(ci): Release workflow failed on every tag whose release already existed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
-# On a version tag, ensure a GitHub Release exists with generated notes. The trained model
-# artifacts (LesNet.M4.5*.keras / .artifacts.json / .tflite) are uploaded to this release by
-# the model-build automation (gh release upload) — they are too large to live in the repo/CI.
+# On a version tag, ensure a GitHub Release exists. Trained model artifacts (the JEPA family
+# tarballs, LesNet.M4.5*.keras / .artifacts.json / .tflite) are uploaded to the release separately
+# by the model-build automation (gh release upload) — far too large to live in the repo/CI.
 on:
   push:
     tags:
@@ -16,12 +16,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Create or update the release
+      - name: Create the release if it does not already exist
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # An existing release is left alone: it normally already carries curated notes and
+          # uploaded model assets, and regenerating notes would silently overwrite them.
+          # The previous version called `gh release edit --generate-notes`, which is not a valid
+          # flag for `edit`, so this step failed every time the release already existed.
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release edit "${GITHUB_REF_NAME}" --generate-notes
+            echo "Release ${GITHUB_REF_NAME} already exists - leaving notes and assets untouched."
           else
-            gh release create "${GITHUB_REF_NAME}" --generate-notes --title "LesNet ${GITHUB_REF_NAME}"
+            gh release create "${GITHUB_REF_NAME}" \
+              --generate-notes --title "LesNet ${GITHUB_REF_NAME}"
           fi


### PR DESCRIPTION
[Run 30226581630](https://github.com/Thomasbehan/LesNet/actions/runs/30226581630) failed on the `v5.0.0` tag:

```
unknown flag: --generate-notes
Usage:  gh release edit <tag>
```

## Root cause

`gh release edit` does not support `--generate-notes` — only `gh release create` does. So this branch of the workflow could **never** succeed:

```bash
if gh release view "$TAG" >/dev/null 2>&1; then
  gh release edit "$TAG" --generate-notes   # always exits 1
else
  gh release create "$TAG" --generate-notes --title "LesNet $TAG"
fi
```

It has been latent since the workflow was written and only passed when the release did *not* already exist, i.e. when the `create` path ran. Pushing `v5.0.0` — whose release was created beforehand so the model assets could be attached — took the broken branch.

## Fix

An existing release is now left alone. This is more than crash-avoidance: had `edit --generate-notes` worked, it would have **overwritten the curated release notes** (metrics tables, limitations, usage) with an autogenerated commit changelog.

Verified locally: YAML parses, shell logic passes `bash -n`, and `gh release edit --help` confirms the flag does not exist.

## Test plan
- [x] `python -c "yaml.safe_load(...)"` parses the workflow
- [x] `bash -n` on the extracted script
- [x] Confirmed against `gh release edit --help`
- [ ] Next `v*` tag push exercises it for real