### PR TITLE
fix(deploy): onnxruntime is a runtime dependency; bake the demo model into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ RUN python3.12 -m pip install --break-system-packages -e .
 RUN apt-get clean
 RUN rm -rf /var/lib/apt/lists/*
 
-# Fetch the released M-4s triage model + artifact bundle into the dir the app loads
-# (LESNET_TRIAGE_ARTIFACTS, default models/triage) so the live demo serves the new model.
-RUN mkdir -p models/triage && \
-    curl -L -o models/triage/triage_model.keras https://github.com/Thomasbehan/LesNet/releases/download/4.1.0/LesNet.M-4s.keras && \
-    curl -L -o models/triage/artifacts.json https://github.com/Thomasbehan/LesNet/releases/download/4.1.0/LesNet.M-4s.artifacts.json
+# Bake in the JEPA medium model the demo serves by default (LESNET_JEPA_HOME, default
+# models/jepa). The app can self-heal by fetching it at runtime, but that would make the first
+# request after a cold start pull 318 MB and very likely time out — so fetch it at build time.
+RUN mkdir -p models/jepa && \
+    curl -fsSL https://github.com/Thomasbehan/LesNet/releases/download/v5.0.0/lesnet-jepa-medium.tar.gz \
+    | tar xz -C models/jepa && \
+    test -f models/jepa/medium/jepa_config.json
 
 # Add a new user to avoid running the application as root; let it write the model dir
 # (so the app's self-healing model fetch works at runtime).

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ requires = [
     'scikit-learn==1.9.0',
     'tqdm==4.68.2',
     'opencv-python-headless==4.13.0.92',
+    # The web demo serves the JEPA family by default (views/api.py), which loads its encoder
+    # through onnxruntime. That made it a RUNTIME dependency of the app, not just of the optional
+    # [jepa] training extra — without it here, a deployment installing only base requires imports
+    # fine and then raises ModuleNotFoundError on the first /predict.
+    'onnxruntime==1.27.0',
 ]
 
 tests_require = [


### PR DESCRIPTION
Fixes the Render deployment.

## `onnxruntime` was missing from base requires

The demo now serves the JEPA family by default (#71), and its encoder loads through `onnxruntime` — but `onnxruntime` was declared only in the optional `[jepa]` **training** extra. The Dockerfile runs `pip install -e .`, i.e. base requires only, so the container imports cleanly and then raises `ModuleNotFoundError: onnxruntime` on the **first `/predict`**.

This is a bug I introduced when changing the default predictor; the dependency became a runtime one and the packaging didn't follow.

## The image fetched a model the demo no longer serves

The Dockerfile pulled the old `M-4s` Keras model. The demo now serves JEPA medium, so the image now bakes that in instead. It *could* self-heal at runtime — `_ensure_jepa_model` downloads on demand — but that would make the first request after a cold start pull **318 MB**, which on Render's free tier will time out and look like a broken app.

## Verified locally

```
extract path matches Dockerfile test: OK
predictor loaded from baked-in path: JEPADemoPredictor | precision fp32
```

The exact `curl … | tar xz -C models/jepa` from the Dockerfile was run, then `_get_predictor()` loaded it with **no environment overrides** — the same path the container takes.

## Test plan
- [x] `ruff check` clean
- [x] 100 tests pass (1 pre-existing Windows-only symlink failure)
- [x] Dockerfile fetch/extract verified end-to-end against the real release asset

Note: this addresses a *runtime* failure I can prove. If Render is failing at **build** time, that may be separate — TensorFlow 2.21 is a very heavy base dependency for a container that no longer needs it for the demo path. I'd want the actual build log before changing that.