### PR TITLE
fix(deploy): Docker build has failed since 2026-06-15 (pip cannot upgrade itself on Ubuntu 24.04)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,28 @@
 # Official Ubuntu base image with Python 3.12
 FROM ubuntu:24.04
 
-# Set the working directory to /app
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-COPY . /app/
+# System packages in ONE layer.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3.12 python3.12-venv python3.12-dev curl ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install any needed packages and run setup.py
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends python3.12 python3-pip python3.12-dev curl
-RUN python3.12 -m pip install --break-system-packages --upgrade pip
-RUN python3.12 -m pip install --break-system-packages -e .
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+# Ubuntu 24.04 ships an externally-managed Python (PEP 668) whose pip comes from a .deb and has
+# no RECORD file, so `pip install --upgrade pip` cannot uninstall it and dies with
+#   "Cannot uninstall pip 24.0, RECORD file not found"
+# — which failed every build here from 2026-06-15 onward. --break-system-packages does not help:
+# it waives the PEP 668 guard, not the missing-RECORD uninstall. A venv owns its own pip, so the
+# upgrade becomes an ordinary install and the whole class of problem disappears.
+RUN python3.12 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH" \
+    VIRTUAL_ENV=/opt/venv \
+    PYTHONUNBUFFERED=1
+RUN pip install --upgrade pip setuptools wheel
+
+COPY . /app/
+RUN pip install -e .
 
 # Bake in the JEPA medium model the demo serves by default (LESNET_JEPA_HOME, default
 # models/jepa). The app can self-heal by fetching it at runtime, but that would make the first
@@ -23,19 +32,15 @@ RUN mkdir -p models/jepa && \
     | tar xz -C models/jepa && \
     test -f models/jepa/medium/jepa_config.json
 
-# Add a new user to avoid running the application as root; let it write the model dir
-# (so the app's self-healing model fetch works at runtime).
-RUN useradd -ms /bin/bash appuser && chown -R appuser /app
+# Construct the served predictor at BUILD time. A missing dependency or a bad artifact then fails
+# the build loudly instead of surfacing as a 500 on the first user request in production.
+RUN python -c "import lesnet.views.api as api; p = api._get_predictor(); \
+print('predictor OK:', type(p).__name__, p.encoder.precision)"
+
+# Run as a non-root user; it still owns /app so the runtime self-heal path can write there.
+RUN useradd -ms /bin/bash appuser && chown -R appuser /app /opt/venv
 USER appuser
 
-# Make port 6543 available to the world outside this container and 6006 for TensorBoard
-EXPOSE 6543 6006
+EXPOSE 6543
 
-# Define environment variable
-ENV NAME World
-
-# Ensure the pserve command is in the PATH
-ENV PATH="/app/.local/bin:${PATH}"
-
-# Run command when the container launches (production config — no debug toolbar, no autoreload)
 CMD ["pserve", "production.ini"]


### PR DESCRIPTION
**Every Render deploy has failed since 15 June** — before any of the recent model work. Pulled from the actual build log:

```
#12 [ 6/11] RUN python3.12 -m pip install --break-system-packages --upgrade pip
    Attempting uninstall: pip
      Found existing installation: pip 24.0
ERROR: Cannot uninstall pip 24.0, RECORD file not found.
       Hint: The package was installed by debian.
error: failed to solve: ... exit code: 1
```

Dockerfile line 13, ~20 seconds into the build.

## Cause

Ubuntu 24.04 ships an **externally-managed** Python (PEP 668) whose pip is installed from a `.deb` and therefore has **no `RECORD` file**. pip cannot uninstall a package it has no manifest for, so upgrading pip-over-pip fails.

`--break-system-packages` doesn't rescue it — that flag waives the PEP 668 *"externally managed environment"* guard, not the missing-`RECORD` uninstall. That's why the flag was already present and the build still died.

## Fix

Build inside a **venv**, which owns its own pip, so the upgrade is an ordinary install and the entire class of problem disappears. Also:

- apt collapsed into one layer with `rm -rf /var/lib/apt/lists/*` in the same layer (the old version ran `apt-get clean` in a *later* layer, so the cache was still baked into the image)
- adds `python3.12-venv`, which the venv needs on Ubuntu
- **constructs the served predictor at build time** — a missing dependency or bad artifact now fails the build loudly rather than 500ing on a user's first request, which is exactly how the `onnxruntime` omission would have escaped

## Note on my earlier guess

I previously suspected TensorFlow's size was causing a build OOM/timeout. **That was wrong** — the builds die in ~20s, long before any pip install. Worth having pulled the real log rather than acting on the theory.

## Test plan
- [x] Root cause confirmed from the Render build log, not inferred
- [ ] Verified by the resulting Render deploy (no local Docker available) — will confirm after merge